### PR TITLE
WIP: Conditional exception validations

### DIFF
--- a/lib/action_logic/action_context.rb
+++ b/lib/action_logic/action_context.rb
@@ -8,6 +8,7 @@ module ActionLogic
 
     def initialize(params = {})
       params[:status] ||= SUCCESS
+      params[:errors] ||= ActionValidation::Errors.new
       super(params)
     end
 

--- a/lib/action_logic/action_core.rb
+++ b/lib/action_logic/action_core.rb
@@ -28,8 +28,8 @@ module ActionLogic
         return execution_context.context if execution_context.break?
 
         execution_context.set_validation_rules
-        execution_context.validations!(:before)
-        execution_context.validations!(:around)
+        execution_context.validations!(:before!)
+        execution_context.validations!(:around!)
 
         begin
           block.call(execution_context)
@@ -41,8 +41,8 @@ module ActionLogic
           end
         end
 
-        execution_context.validations!(:after)
-        execution_context.validations!(:around)
+        execution_context.validations!(:after!)
+        execution_context.validations!(:around!)
 
         execution_context.context
       end

--- a/lib/action_logic/action_core.rb
+++ b/lib/action_logic/action_core.rb
@@ -28,8 +28,11 @@ module ActionLogic
         return execution_context.context if execution_context.break?
 
         execution_context.set_validation_rules
+        execution_context.set_validation_bang_rules
         execution_context.validations!(:before!)
         execution_context.validations!(:around!)
+        execution_context.validations(:before)
+        execution_context.validations(:around)
 
         begin
           block.call(execution_context)
@@ -43,6 +46,8 @@ module ActionLogic
 
         execution_context.validations!(:after!)
         execution_context.validations!(:around!)
+        execution_context.validations(:after)
+        execution_context.validations(:around)
 
         execution_context.context
       end

--- a/lib/action_logic/action_validation.rb
+++ b/lib/action_logic/action_validation.rb
@@ -43,9 +43,9 @@ module ActionLogic
 
     def validations!(validation_order)
       case validation_order
-      when :before then validations.each { |validation| validate!(validation, @before_validation_rules) }
-      when :after  then validations.each { |validation| validate!(validation, @after_validation_rules) }
-      when :around then validations.each { |validation| validate!(validation, @around_validation_rules) }
+      when :before! then validations.each { |validation| validate!(validation, @before_validation_rules) }
+      when :after!  then validations.each { |validation| validate!(validation, @after_validation_rules) }
+      when :around! then validations.each { |validation| validate!(validation, @around_validation_rules) }
       end
     end
 

--- a/lib/action_logic/action_validation/attribute_validation.rb
+++ b/lib/action_logic/action_validation/attribute_validation.rb
@@ -12,6 +12,16 @@ module ActionLogic
 
         raise ActionLogic::MissingAttributeError.new(error_message_format(missing_attributes.join(", ") + " attributes are missing")) if missing_attributes.any?
       end
+
+      def self.validate(validation_rules, context)
+        existing_attributes = context.to_h.keys
+        expected_attributes = validation_rules.keys || []
+        missing_attributes  = expected_attributes - existing_attributes
+
+        missing_attributes.each do |attribute|
+          context.errors.messages[attribute] = attribute.to_s + " is missing"
+        end
+      end
     end
   end
 end

--- a/lib/action_logic/action_validation/errors.rb
+++ b/lib/action_logic/action_validation/errors.rb
@@ -1,0 +1,11 @@
+module ActionLogic
+  module ActionValidation
+    class Errors
+      attr_accessor :messages
+
+      def initialize
+        @messages = Hash.new { |messages, attribute| messages[attribute] = [] }
+      end
+    end
+  end
+end

--- a/lib/action_logic/action_validation/presence_validation.rb
+++ b/lib/action_logic/action_validation/presence_validation.rb
@@ -7,7 +7,11 @@ module ActionLogic
 
       def self.validate!(validation_rules, context)
         return unless validation_rules.values.find { |expected_validation| expected_validation[:presence] }
-        errors = presence_errors(validation_rules, context)
+        errors = validation_rules.reduce([]) do |error_collection, (expected_attribute, expected_validation)|
+          next unless expected_validation[:presence]
+          error_collection << error_message(expected_attribute, expected_validation, context)
+          error_collection
+        end || []
         raise ActionLogic::PresenceError.new(errors) if errors.any?
       end
 
@@ -23,6 +27,23 @@ module ActionLogic
         case expected_validation[:presence]
         when TrueClass then "Attribute: #{expected_attribute} is missing value in context but presence validation was specified" unless context[expected_attribute]
         when Proc      then "Attribute: #{expected_attribute} is missing value in context but custom presence validation was specified" unless expected_validation[:presence].call(context[expected_attribute])
+        else
+          raise ActionLogic::UnrecognizablePresenceValidatorError.new(error_message_format("Presence validator: #{expected_validation[:presence]} is not a supported format"))
+        end
+      end
+
+      def self.validate(validation_rules, context)
+        return unless validation_rules.values.find { |expected_validation| expected_validation[:presence] }
+        validation_rules.each do |(expected_attribute, expected_validation)|
+          next unless expected_validation[:presence]
+          context.errors.messages[expected_attribute] << "Missing value according to presence validation" if error?(expected_attribute, expected_validation, context)
+        end
+      end
+
+      def self.error?(expected_attribute, expected_validation, context)
+        case expected_validation[:presence]
+        when TrueClass then false if context[expected_attribute]
+        when Proc      then expected_validation[:presence].call(context[expected_attribute])
         else
           raise ActionLogic::UnrecognizablePresenceValidatorError.new(error_message_format("Presence validator: #{expected_validation[:presence]} is not a supported format"))
         end

--- a/lib/action_logic/action_validation/type_validation.rb
+++ b/lib/action_logic/action_validation/type_validation.rb
@@ -19,6 +19,19 @@ module ActionLogic
 
         raise ActionLogic::AttributeTypeError.new(error_message_format(type_errors.join(", "))) if type_errors.any?
       end
+
+      def self.validate(validation_rules, context)
+        return unless validation_rules.values.find { |expected_validation| expected_validation[:type] }
+
+        validation_rules.reduce([]) do |collection, (expected_attribute, expected_validation)|
+          next unless expected_validation[:type]
+
+          if context.to_h[expected_attribute].class != expected_validation[:type]
+            context.errors.messages[expected_attribute] = "Value expected to be of type #{expected_validation[:type]} but is #{context.to_h[expected_attribute].class}"
+          end
+          collection
+        end
+      end
     end
   end
 end

--- a/spec/action_logic/active_use_case_spec.rb
+++ b/spec/action_logic/active_use_case_spec.rb
@@ -42,135 +42,153 @@ module ActionLogic
       end
     end
 
-    describe "around validations" do
+    describe "validations" do
       describe "required attributes and type validation" do
-        it "does not raise error if context has required keys and values are of the correct type" do
-          expect { ValidateAroundTestUseCase.execute(Constants::VALID_ATTRIBUTES) }.to_not raise_error
+        describe "with validation! methods" do
+          it "does not raise error if context has required keys and values are of the correct type" do
+            expect { ValidateAroundTestUseCaseWithBang.execute(Constants::VALID_ATTRIBUTES) }.to_not raise_error
+
+            expect { ValidateBeforeTestUseCaseWithBang.execute(Constants::VALID_ATTRIBUTES) }.to_not raise_error
+
+            expect { ValidateAfterTestUseCaseWithBang.execute() }.to_not raise_error
+          end
+
+          it "raises error if context is missing required keys" do
+            expect { ValidateAroundTestUseCaseWithBang.execute() }.to\
+              raise_error(ActionLogic::MissingAttributeError)
+
+            expect { ValidateBeforeTestUseCaseWithBang.execute() }.to\
+              raise_error(ActionLogic::MissingAttributeError)
+
+            expect { ValidateAfterMissingAttributesTestUseCaseWithBang.execute() }.to\
+              raise_error(ActionLogic::MissingAttributeError)
+          end
+
+          it "raises error if context has required keys but values are not of correct type" do
+            expect { ValidateAroundTestUseCaseWithBang.execute(Constants::INVALID_ATTRIBUTES) }.to\
+              raise_error(ActionLogic::AttributeTypeError)
+
+            expect { ValidateBeforeTestUseCaseWithBang.execute(Constants::INVALID_ATTRIBUTES) }.to\
+              raise_error(ActionLogic::AttributeTypeError)
+
+            expect { ValidateAfterInvalidTypeTestUseCaseWithBang.execute() }.to\
+              raise_error(ActionLogic::AttributeTypeError)
+          end
         end
 
-        it "raises error if context is missing required keys" do
-          expect { ValidateAroundTestUseCase.execute() }.to\
-            raise_error(ActionLogic::MissingAttributeError)
-        end
+        describe "with validation methods" do
+          xit "does not record error messages if context has required keys and values are of the correct type" do
+            expect(ValidateAroundTestUseCase.execute(Constants::VALID_ATTRIBUTES).errors.messages).to eq({})
+          end
 
-        it "raises error if context has required keys but values are not of correct type" do
-          expect { ValidateAroundTestUseCase.execute(Constants::INVALID_ATTRIBUTES) }.to\
-            raise_error(ActionLogic::AttributeTypeError)
+          xit "records error messages if context is missing required keys" do
+            expect(ValidateAroundTestUseCase.execute().errors.messages).to eq({:integer_test=>"Value expected to be of type Fixnum but is NilClass", :float_test=>"Value expected to be of type Float but is NilClass", :string_test=>"Value expected to be of type String but is NilClass", :bool_test=>"Value expected to be of type TrueClass but is NilClass", :hash_test=>"Value expected to be of type Hash but is NilClass", :array_test=>"Value expected to be of type Array but is NilClass", :symbol_test=>"Value expected to be of type Symbol but is NilClass", :nil_test=>"nil_test is missing"})
+          end
+
+          xit "records error messages if context has required keys but values are not of correct type" do
+            expect(ValidateAroundTestUseCase.execute(Constants::INVALID_ATTRIBUTES).errors.messages).to eq({:integer_test=>"Value expected to be of type Fixnum but is NilClass", :float_test=>"Value expected to be of type Float but is NilClass", :string_test=>"Value expected to be of type String but is NilClass", :bool_test=>"Value expected to be of type TrueClass but is NilClass", :hash_test=>"Value expected to be of type Hash but is NilClass", :array_test=>"Value expected to be of type Array but is NilClass", :symbol_test=>"Value expected to be of type Symbol but is NilClass", :nil_test=>"Value expected to be of type NilClass but is Fixnum"})
+          end
         end
       end
 
       describe "custom types" do
-        it "allows validation against custom defined types" do
-          expect { ValidateAroundCustomTypeTestUseCase.execute(:custom_type => CustomType1.new) }.to_not raise_error
+        describe "with validation! methods" do
+          it "does not raise error if context has required keys and values match against custom defined types" do
+            expect { ValidateAroundCustomTypeTestUseCaseWithBang.execute(:custom_type => CustomType1.new) }.to_not raise_error
+            expect { ValidateBeforeCustomTypeTestUseCaseWithBang.execute(Constants::CUSTOM_TYPE_ATTRIBUTES1) }.to_not raise_error
+          end
+
+          it "raises error if context has custom defined type attribute but value is not of the correct type" do
+            expect { ValidateAroundCustomTypeTestUseCaseWithBang.execute(:custom_type => CustomType2.new) }.to\
+              raise_error(ActionLogic::AttributeTypeError)
+
+            expect { ValidateBeforeCustomTypeTestUseCaseWithBang.execute(Constants::CUSTOM_TYPE_ATTRIBUTES2) }.to\
+              raise_error(ActionLogic::AttributeTypeError)
+          end
         end
 
-        it "raises error if context has custom type attribute but value is not correct custom type" do
-          expect { ValidateAroundCustomTypeTestUseCase.execute(:custom_type => CustomType2.new) }.to\
-            raise_error(ActionLogic::AttributeTypeError)
-        end
-      end
+        describe "with validation methods" do
+          xit "does not record error messages if context has required keys and values match against custom defined types" do
+            expect(ValidateAroundCustomTypeTestUseCase.execute(:custom_type => CustomType1.new).errors.messages).to eq({})
+          end
 
-      describe "presence" do
-        it "validates presence if presence is specified" do
-          expect { ValidateAroundPresenceTestUseCase.execute(:integer_test => 1) }.to_not raise_error
-        end
-
-        it "raises error if context has required key but value is not defined when validation requires presence" do
-          expect { ValidateAroundPresenceTestUseCase.execute(:integer_test => nil) }.to\
-            raise_error(ActionLogic::PresenceError)
-        end
-      end
-
-      describe "custom presence" do
-        it "allows custom presence validation if custom presence is defined" do
-          expect { ValidateAroundCustomPresenceTestUseCase.execute(:array_test => [1]) }.to_not raise_error
-        end
-
-        it "raises error if custom presence validation is not satisfied" do
-          expect { ValidateAroundCustomPresenceTestUseCase.execute(:array_test => []) }.to\
-            raise_error(ActionLogic::PresenceError)
-        end
-
-        it "raises error if custom presence validation is not supported" do
-          expect { ValidateAroundUnrecognizablePresenceTestUseCase.execute(:integer_test => 1) }.to\
-            raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
-        end
-      end
-    end
-
-    describe "before validations" do
-      describe "required attributes and type validation" do
-        it "does not raise error if context has required keys and values are of the correct type" do
-          expect { ValidateBeforeTestUseCase.execute(Constants::VALID_ATTRIBUTES) }.to_not raise_error
-        end
-
-        it "raises error if context is missing required keys" do
-          expect { ValidateBeforeTestUseCase.execute() }.to\
-            raise_error(ActionLogic::MissingAttributeError)
-        end
-
-        it "raises error if context has required key but is not of correct type" do
-          expect { ValidateBeforeTestUseCase.execute(Constants::INVALID_ATTRIBUTES) }.to\
-            raise_error(ActionLogic::AttributeTypeError)
-        end
-      end
-
-      describe "custom types" do
-        it "allows validation against custom defined types" do
-          expect { ValidateBeforeCustomTypeTestUseCase.execute(Constants::CUSTOM_TYPE_ATTRIBUTES1) }.to_not raise_error
-        end
-
-        it "raises error if context has custom type attribute but value is not correct custom type" do
-          expect { ValidateBeforeCustomTypeTestUseCase.execute(Constants::CUSTOM_TYPE_ATTRIBUTES2) }.to\
-            raise_error(ActionLogic::AttributeTypeError)
+          xit "records error messages if context has custom type attribute but value is not correct custom type" do
+            expect(ValidateAroundCustomTypeTestUseCase.execute(:custom_type => CustomType2.new).errors.messages).to eq({:custom_type=>"Value expected to be of type CustomType1 but is CustomType2"})
+          end
         end
       end
 
       describe "presence" do
-        it "validates presence if presence is specified" do
-          expect { ValidateBeforePresenceTestUseCase.execute(:integer_test => 1) }.to_not raise_error
+        describe "with validation! methods" do
+          it "validates presence if presence is specified" do
+            expect { ValidateAroundPresenceTestUseCaseWithBang.execute(:integer_test => 1) }.to_not raise_error
+            expect { ValidateBeforePresenceTestUseCase.execute(:integer_test => 1) }.to_not raise_error
+          end
+
+          it "raises error if context has required key but value is not defined when validation requires presence" do
+            expect { ValidateAroundPresenceTestUseCaseWithBang.execute(:integer_test => nil) }.to\
+              raise_error(ActionLogic::PresenceError)
+
+            expect { ValidateBeforePresenceTestUseCase.execute(:integer_test => nil) }.to\
+              raise_error(ActionLogic::PresenceError)
+          end
         end
 
-        it "raises error if context has required key but value is not defined when validation requires presence" do
-          expect { ValidateBeforePresenceTestUseCase.execute(:integer_test => nil) }.to\
-            raise_error(ActionLogic::PresenceError)
+        describe "with validation methods" do
+          xit "validates presence if presence is specified" do
+            expect { ValidateAroundPresenceTestUseCase.execute(:integer_test => 1) }.to_not raise_error
+          end
+
+          xit "raises error if context has required key but value is not defined when validation requires presence" do
+            expect { ValidateAroundPresenceTestUseCase.execute(:integer_test => nil) }.to\
+              raise_error(ActionLogic::PresenceError)
+          end
         end
       end
 
       describe "custom presence" do
-        it "allows custom presence validation if custom presence is defined" do
-          expect { ValidateBeforeCustomPresenceTestUseCase.execute(:array_test => [1]) }.to_not raise_error
+        describe "with validation! methods" do
+          it "allows custom presence validation if custom presence is defined" do
+            expect { ValidateAroundCustomPresenceTestUseCaseWithBang.execute(:array_test => [1]) }.to_not raise_error
+            expect { ValidateBeforeCustomPresenceTestUseCaseWithBang.execute(:array_test => [1]) }.to_not raise_error
+          end
+
+          it "raises error if custom presence validation is not satisfied" do
+            expect { ValidateAroundCustomPresenceTestUseCaseWithBang.execute(:array_test => []) }.to\
+              raise_error(ActionLogic::PresenceError)
+
+            expect { ValidateBeforeCustomPresenceTestUseCaseWithBang.execute(:array_test => []) }.to\
+              raise_error(ActionLogic::PresenceError)
+          end
+
+          it "raises error if custom presence validation is not supported" do
+            expect { ValidateAroundUnrecognizablePresenceTestUseCaseWithBang.execute(:integer_test => 1) }.to\
+              raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
+
+            expect { ValidateBeforeUnrecognizablePresenceTestUseCaseWithBang.execute(:integer_test => 1) }.to\
+              raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
+          end
         end
 
-        it "raises error if custom presence validation is not satisfied" do
-          expect { ValidateBeforeCustomPresenceTestUseCase.execute(:array_test => []) }.to\
-            raise_error(ActionLogic::PresenceError)
-        end
+        describe "with validation methods" do
+          xit "allows custom presence validation if custom presence is defined" do
+            expect { ValidateAroundCustomPresenceTestUseCase.execute(:array_test => [1]) }.to_not raise_error
+          end
 
-        it "raises error if custom presence validation is not supported" do
-          expect { ValidateBeforeUnrecognizablePresenceTestUseCase.execute(:integer_test => 1) }.to\
-            raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
+          xit "raises error if custom presence validation is not satisfied" do
+            expect { ValidateAroundCustomPresenceTestUseCase.execute(:array_test => []) }.to\
+              raise_error(ActionLogic::PresenceError)
+          end
+
+          xit "raises error if custom presence validation is not supported" do
+            expect { ValidateAroundUnrecognizablePresenceTestUseCase.execute(:integer_test => 1) }.to\
+              raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
+          end
         end
       end
     end
 
     describe "after validations" do
-      describe "required attributes and type validation" do
-        it "does not raise error if the task sets all required keys and values are of the correct type" do
-          expect { ValidateAfterTestUseCase.execute() }.to_not raise_error
-        end
-
-        it "raises error if task does not provide the necessary keys" do
-          expect { ValidateAfterMissingAttributesTestUseCase.execute() }.to\
-            raise_error(ActionLogic::MissingAttributeError)
-        end
-
-        it "raises error if task has required key but is not of correct type" do
-          expect { ValidateAfterInvalidTypeTestUseCase.execute() }.to\
-            raise_error(ActionLogic::AttributeTypeError)
-        end
-      end
-
       describe "custom types" do
         it "allows validation against custom defined types" do
           expect { ValidateAfterCustomTypeTestUseCase.execute() }.to_not raise_error

--- a/spec/fixtures/coordinators.rb
+++ b/spec/fixtures/coordinators.rb
@@ -61,7 +61,7 @@ end
 class ValidateBeforeTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_before Constants::ALL_VALIDATIONS
+  validates_before! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -80,7 +80,7 @@ end
 class ValidateBeforeCustomTypeTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_before Constants::CUSTOM_TYPE_VALIDATION1
+  validates_before! Constants::CUSTOM_TYPE_VALIDATION1
 
   def call
   end
@@ -99,7 +99,7 @@ end
 class ValidateBeforePresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_before Constants::PRESENCE_VALIDATION
+  validates_before! Constants::PRESENCE_VALIDATION
 
   def call
   end
@@ -118,7 +118,7 @@ end
 class ValidateBeforeCustomPresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_before Constants::CUSTOM_PRESENCE_VALIDATION
+  validates_before! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
   end
@@ -137,7 +137,7 @@ end
 class ValidateBeforeUnrecognizablePresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_before :integer_test => { :presence => :true }
+  validates_before! :integer_test => { :presence => :true }
 
   def call
   end
@@ -156,7 +156,7 @@ end
 class ValidateAfterTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
     context.integer_test = 1
@@ -183,7 +183,7 @@ end
 class ValidateAfterMissingAttributesTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -202,7 +202,7 @@ end
 class ValidateAfterInvalidTypeTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
     context.integer_test = nil
@@ -229,7 +229,7 @@ end
 class ValidateAfterCustomTypeTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::CUSTOM_TYPE_VALIDATION1
+  validates_after! Constants::CUSTOM_TYPE_VALIDATION1
 
   def call
     context.custom_type = CustomType1.new
@@ -249,7 +249,7 @@ end
 class ValidateAfterInvalidCustomTypeTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::CUSTOM_TYPE_VALIDATION2
+  validates_after! Constants::CUSTOM_TYPE_VALIDATION2
 
   def call
     context.custom_type = CustomType1.new
@@ -269,7 +269,7 @@ end
 class ValidateAfterPresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::PRESENCE_VALIDATION
+  validates_after! Constants::PRESENCE_VALIDATION
 
   def call
     context.integer_test = 1
@@ -289,7 +289,7 @@ end
 class ValidateAfterInvalidPresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::PRESENCE_VALIDATION
+  validates_after! Constants::PRESENCE_VALIDATION
 
   def call
     context.integer_test = nil
@@ -309,7 +309,7 @@ end
 class ValidateAfterCustomPresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::CUSTOM_PRESENCE_VALIDATION
+  validates_after! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
     context.array_test = [1]
@@ -329,7 +329,7 @@ end
 class ValidateAfterInvalidCustomPresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after Constants::CUSTOM_PRESENCE_VALIDATION
+  validates_after! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
     context.array_test = []
@@ -349,7 +349,7 @@ end
 class ValidateAfterUnrecognizablePresenceTestCoordinator
   include ActionLogic::ActionCoordinator
 
-  validates_after :integer_test => { :presence => :true }
+  validates_after! :integer_test => { :presence => :true }
 
   def call
     context.integer_test = 1

--- a/spec/fixtures/tasks.rb
+++ b/spec/fixtures/tasks.rb
@@ -13,7 +13,7 @@ end
 class ValidateAroundTestTask
   include ActionLogic::ActionTask
 
-  validates_around Constants::ALL_VALIDATIONS
+  validates_around! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -22,7 +22,7 @@ end
 class ValidateAroundCustomTypeTestTask
   include ActionLogic::ActionTask
 
-  validates_around :custom_type => { :type => CustomType1, :presence => true }
+  validates_around! :custom_type => { :type => CustomType1, :presence => true }
 
   def call
   end
@@ -31,7 +31,7 @@ end
 class ValidateAroundUnrecognizablePresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_around :integer_test => { :presence => :true }
+  validates_around! :integer_test => { :presence => :true }
 
   def call
   end
@@ -40,7 +40,7 @@ end
 class ValidateAroundPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_around :integer_test => { :presence => true }
+  validates_around! :integer_test => { :presence => true }
 
   def call
   end
@@ -49,7 +49,7 @@ end
 class ValidateAroundCustomPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_around :array_test => { :presence => ->(array_test) { array_test.any? } }
+  validates_around! :array_test => { :presence => ->(array_test) { array_test.any? } }
 
   def call
   end
@@ -62,7 +62,7 @@ end
 class ValidateBeforeTestTask
   include ActionLogic::ActionTask
 
-  validates_before Constants::ALL_VALIDATIONS
+  validates_before! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -71,7 +71,7 @@ end
 class ValidateBeforeCustomTypeTestTask
   include ActionLogic::ActionTask
 
-  validates_before :custom_type => { :type => CustomType1, :presence => true }
+  validates_before! :custom_type => { :type => CustomType1, :presence => true }
 
   def call
   end
@@ -80,7 +80,7 @@ end
 class ValidateBeforeUnrecognizablePresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_before :integer_test => { :presence => :true }
+  validates_before! :integer_test => { :presence => :true }
 
   def call
   end
@@ -89,7 +89,7 @@ end
 class ValidateBeforePresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_before :integer_test => { :presence => true }
+  validates_before! :integer_test => { :presence => true }
 
   def call
   end
@@ -98,7 +98,7 @@ end
 class ValidateBeforeCustomPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_before :array_test => { :presence => ->(array_test) { array_test.any? } }
+  validates_before! :array_test => { :presence => ->(array_test) { array_test.any? } }
 
   def call
   end
@@ -111,7 +111,7 @@ end
 class ValidateAfterTestTask
   include ActionLogic::ActionTask
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
     context.integer_test = 1
@@ -128,7 +128,7 @@ end
 class ValidateAfterMissingAttributesTestTask
   include ActionLogic::ActionTask
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -137,7 +137,7 @@ end
 class ValidateAfterInvalidTypeTestTask
   include ActionLogic::ActionTask
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
     context.integer_test = nil
@@ -154,7 +154,7 @@ end
 class ValidateAfterCustomTypeTestTask
   include ActionLogic::ActionTask
 
-  validates_after :custom_type => { :type => CustomType1, :presence => true }
+  validates_after! :custom_type => { :type => CustomType1, :presence => true }
 
   def call
     context.custom_type = CustomType1.new
@@ -164,7 +164,7 @@ end
 class ValidateAfterInvalidCustomTypeTestTask
   include ActionLogic::ActionTask
 
-  validates_after :custom_type => { :type => CustomType2, :presence => true }
+  validates_after! :custom_type => { :type => CustomType2, :presence => true }
 
   def call
     context.custom_type = CustomType1.new
@@ -174,7 +174,7 @@ end
 class ValidateAfterPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_after :integer_test => { :presence => true }
+  validates_after! :integer_test => { :presence => true }
 
   def call
     context.integer_test = 1
@@ -184,7 +184,7 @@ end
 class ValidateAfterInvalidPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_after :integer_test => { :presence => true }
+  validates_after! :integer_test => { :presence => true }
 
   def call
     context.integer_test = nil
@@ -194,7 +194,7 @@ end
 class ValidateAfterCustomPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_after :array_test => { :presence => ->(array_test) { array_test.any? } }
+  validates_after! :array_test => { :presence => ->(array_test) { array_test.any? } }
 
   def call
     context.array_test = [1]
@@ -204,7 +204,7 @@ end
 class ValidateAfterInvalidCustomPresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_after :array_test => { :presence => ->(array_test) { array_test.any? } }
+  validates_after! :array_test => { :presence => ->(array_test) { array_test.any? } }
 
   def call
     context.array_test = []
@@ -214,7 +214,7 @@ end
 class ValidateAfterUnrecognizablePresenceTestTask
   include ActionLogic::ActionTask
 
-  validates_after :integer_test => { :presence => :true }
+  validates_after! :integer_test => { :presence => :true }
 
   def call
     context.integer_test = 1
@@ -236,7 +236,7 @@ end
 class ErrorHandlerInvalidAttributesBeforeTestTask
   include ActionLogic::ActionTask
 
-  validates_before Constants::ALL_VALIDATIONS
+  validates_before! Constants::ALL_VALIDATIONS
 
   def call
     raise
@@ -250,7 +250,7 @@ end
 class ErrorHandlerInvalidAttributesAfterTestTask
   include ActionLogic::ActionTask
 
-  validates_after Constants::ALL_VALIDATIONS
+  validates_after! Constants::ALL_VALIDATIONS
 
   def call
     raise

--- a/spec/fixtures/use_cases.rb
+++ b/spec/fixtures/use_cases.rb
@@ -49,10 +49,38 @@ class NoTaskTestUseCase
   end
 end
 
+class ValidateAroundTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_around! Constants::ALL_VALIDATIONS
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateAroundTestUseCase
   include ActionLogic::ActionUseCase
 
   validates_around Constants::ALL_VALIDATIONS
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateAroundCustomTypeTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_around! :custom_type => { :type => CustomType1, :presence => true }
 
   def call
   end
@@ -77,10 +105,38 @@ class ValidateAroundCustomTypeTestUseCase
   end
 end
 
+class ValidateAroundUnrecognizablePresenceTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_around! :integer_test => { :presence => :true }
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateAroundUnrecognizablePresenceTestUseCase
   include ActionLogic::ActionUseCase
 
   validates_around :integer_test => { :presence => :true }
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateAroundPresenceTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_around! :integer_test => { :presence => true }
 
   def call
   end
@@ -105,10 +161,38 @@ class ValidateAroundPresenceTestUseCase
   end
 end
 
+class ValidateAroundCustomPresenceTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_around! :array_test => { :presence => ->(array_test) { array_test.any? } }
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateAroundCustomPresenceTestUseCase
   include ActionLogic::ActionUseCase
 
   validates_around :array_test => { :presence => ->(array_test) { array_test.any? } }
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateBeforeTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_before! Constants::ALL_VALIDATIONS
 
   def call
   end
@@ -136,7 +220,21 @@ end
 class ValidateBeforePresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_before Constants::PRESENCE_VALIDATION
+  validates_before! Constants::PRESENCE_VALIDATION
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateBeforeCustomPresenceTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_before! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
   end
@@ -161,10 +259,38 @@ class ValidateBeforeCustomPresenceTestUseCase
   end
 end
 
+class ValidateBeforeCustomTypeTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_before! Constants::CUSTOM_TYPE_VALIDATION1
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateBeforeCustomTypeTestUseCase
   include ActionLogic::ActionUseCase
 
   validates_before Constants::CUSTOM_TYPE_VALIDATION1
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateBeforeUnrecognizablePresenceTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_before! :integer_test => { :presence => :true }
 
   def call
   end
@@ -189,6 +315,27 @@ class ValidateBeforeUnrecognizablePresenceTestUseCase
   end
 end
 
+class ValidateAfterTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_after! Constants::ALL_VALIDATIONS
+
+  def call
+    context.integer_test = 1
+    context.float_test   = 1.0
+    context.string_test  = "string"
+    context.bool_test    = true
+    context.hash_test    = {}
+    context.array_test   = []
+    context.symbol_test  = :symbol
+    context.nil_test     = nil
+  end
+
+  def tasks
+    [UseCaseTestTask3]
+  end
+end
+
 class ValidateAfterTestUseCase
   include ActionLogic::ActionUseCase
 
@@ -210,12 +357,48 @@ class ValidateAfterTestUseCase
   end
 end
 
+class ValidateAfterMissingAttributesTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_after! Constants::ALL_VALIDATIONS
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateAfterMissingAttributesTestUseCase
   include ActionLogic::ActionUseCase
 
   validates_after Constants::ALL_VALIDATIONS
 
   def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
+class ValidateAfterInvalidTypeTestUseCaseWithBang
+  include ActionLogic::ActionUseCase
+
+  validates_after! Constants::ALL_VALIDATIONS
+
+  def call
+    context.integer_test = nil
+    context.float_test   = nil
+    context.string_test  = nil
+    context.bool_test    = nil
+    context.hash_test    = nil
+    context.array_test   = nil
+    context.symbol_test  = nil
+    context.nil_test     = 1
   end
 
   def tasks
@@ -249,7 +432,7 @@ end
 class ValidateAfterCustomTypeTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::CUSTOM_TYPE_VALIDATION1
+  validates_after! Constants::CUSTOM_TYPE_VALIDATION1
 
   def call
     context.custom_type = CustomType1.new
@@ -264,7 +447,7 @@ end
 class ValidateAfterInvalidCustomTypeTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::CUSTOM_TYPE_VALIDATION2
+  validates_after! Constants::CUSTOM_TYPE_VALIDATION2
 
   def call
     context.custom_type = CustomType1.new
@@ -279,7 +462,7 @@ end
 class ValidateAfterPresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::PRESENCE_VALIDATION
+  validates_after! Constants::PRESENCE_VALIDATION
 
   def call
     context.integer_test = 1
@@ -293,7 +476,7 @@ end
 class ValidateAfterInvalidPresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::PRESENCE_VALIDATION
+  validates_after! Constants::PRESENCE_VALIDATION
 
   def call
     context.integer_test = nil
@@ -308,7 +491,7 @@ end
 class ValidateAfterCustomPresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::CUSTOM_PRESENCE_VALIDATION
+  validates_after! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
     context.array_test = [1]
@@ -323,7 +506,7 @@ end
 class ValidateAfterInvalidCustomPresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after Constants::CUSTOM_PRESENCE_VALIDATION
+  validates_after! Constants::CUSTOM_PRESENCE_VALIDATION
 
   def call
     context.array_test = []
@@ -338,7 +521,7 @@ end
 class ValidateAfterUnrecognizablePresenceTestUseCase
   include ActionLogic::ActionUseCase
 
-  validates_after :integer_test => { :presence => :true }
+  validates_after! :integer_test => { :presence => :true }
 
   def call
     context.integer_test = 1


### PR DESCRIPTION
Taking inspiration from https://github.com/rewinfrey/ActionLogic/pull/10 I wanted to see how it felt maintaining two sets of validation methods and invoke them at the `ActionLogic::ActionCore` level.

I also took inspiration from [`ActiveModel::Errors`](http://api.rubyonrails.org/classes/ActiveModel/Validations.html#method-i-errors) so if the non-bang validation method is used and errors are found, `ActionLogic` provides a `context.errors.messages` interface:

```ruby
{
  :integer_attribute=>"Value expected to be of type Fixnum but is NilClass", 
  :float_attribute=>"Value expected to be of type Float but is NilClass"
}
```

I've updated the three types of validations (Attribute, Presence and Type) to support this difference, and am still working through updating the tests and fixtures.

My goal isn't to replace https://github.com/rewinfrey/ActionLogic/pull/10 but to compare approaches and see if some mix and match would be ideal, or if we like one direction or the other.

/cc @davesims 

