### PR TITLE
Fixing Error Received When First Validator is a Custom Presence Validator

### DIFF
--- a/lib/action_logic/action_validation/type_validation.rb
+++ b/lib/action_logic/action_validation/type_validation.rb
@@ -9,7 +9,7 @@ module ActionLogic
         return unless validation_rules.values.find { |expected_validation| expected_validation[:type] }
 
         type_errors = validation_rules.reduce([]) do |collection, (expected_attribute, expected_validation)|
-          next unless expected_validation[:type]
+          next collection unless expected_validation[:type]
 
           if context.to_h[expected_attribute].class != expected_validation[:type]
             collection << "Attribute: #{expected_attribute} with value: #{context.to_h[expected_attribute]} was expected to be of type #{expected_validation[:type]} but is #{context.to_h[expected_attribute].class}"

--- a/spec/action_logic/active_use_case_spec.rb
+++ b/spec/action_logic/active_use_case_spec.rb
@@ -152,6 +152,27 @@ module ActionLogic
             raise_error(ActionLogic::UnrecognizablePresenceValidatorError)
         end
       end
+
+      describe "mixed custom presence and type" do
+        it "allows custom presence validation to be defined without type if a type validation is defined" do
+          expect { ValidateBeforeMixedTypeAndPresenceUseCase.execute(odd_integer_test: 1, string_test: "Test") }.to_not raise_error
+        end
+
+        it "raises error if custom presence validation is not satisfied" do
+          expect { ValidateBeforeMixedTypeAndPresenceUseCase.execute(odd_integer_test: 2, string_test: "Test") }.to \
+            raise_error(ActionLogic::PresenceError)
+        end
+
+        it "raises error if type validation is not satisfied" do
+          expect { ValidateBeforeMixedTypeAndPresenceUseCase.execute(odd_integer_test: 1, string_test: 15) }.to \
+            raise_error(ActionLogic::AttributeTypeError)
+        end
+
+        it "raises error if type presence validation is not satisfied" do
+          expect { ValidateBeforeMixedTypeAndPresenceUseCase.execute(odd_integer_test: 1) }.to \
+            raise_error(ActionLogic::MissingAttributeError)
+        end
+      end
     end
 
     describe "after validations" do

--- a/spec/fixtures/use_cases.rb
+++ b/spec/fixtures/use_cases.rb
@@ -189,6 +189,21 @@ class ValidateBeforeUnrecognizablePresenceTestUseCase
   end
 end
 
+class ValidateBeforeMixedTypeAndPresenceUseCase
+  include ActionLogic::ActionUseCase
+
+  validates_before odd_integer_test: { presence: ->(i) { i % 2 != 0 } },
+                   string_test: { type: String, presence: true }
+
+  def call
+  end
+
+  def tasks
+    [UseCaseTestTask1,
+     UseCaseTestTask2]
+  end
+end
+
 class ValidateAfterTestUseCase
   include ActionLogic::ActionUseCase
 


### PR DESCRIPTION
Received <NoMethodError: undefined method 'any?' for nil:NilClass> when
validating with a presence validator before a type validator was
defined. This was because the reduction within the type validators did
not return the collection on `next`.