### PR TITLE
Fix bug caused by not returning accumulator if presence isn't included in the validation definition

### DIFF
--- a/lib/action_logic/action_validation/presence_validation.rb
+++ b/lib/action_logic/action_validation/presence_validation.rb
@@ -13,10 +13,8 @@ module ActionLogic
 
       def self.presence_errors(validation_rules, context)
         validation_rules.reduce([]) do |error_collection, (expected_attribute, expected_validation)|
-          if expected_validation[:presence]
+          next error_collection unless expected_validation[:presence]
             error_collection << error_message(expected_attribute, expected_validation, context)
-            error_collection
-          else
             error_collection
           end
         end || []

--- a/lib/action_logic/action_validation/presence_validation.rb
+++ b/lib/action_logic/action_validation/presence_validation.rb
@@ -13,9 +13,12 @@ module ActionLogic
 
       def self.presence_errors(validation_rules, context)
         validation_rules.reduce([]) do |error_collection, (expected_attribute, expected_validation)|
-          next unless expected_validation[:presence]
-          error_collection << error_message(expected_attribute, expected_validation, context)
-          error_collection
+          if expected_validation[:presence]
+            error_collection << error_message(expected_attribute, expected_validation, context)
+            error_collection
+          else
+            error_collection
+          end
         end || []
       end
 


### PR DESCRIPTION
## Overview

When some validations include the presence key and others do not, this error is raised:

```
NoMethodError:
       undefined method `<<' for nil:NilClass
```

It's because the accumulator is not returned for those validation expectations that don't include the `presence` key. So in the iteration following such a definition, `error_collection` is `nil`.